### PR TITLE
Update docs for latest LightNet features

### DIFF
--- a/src/content/docs/build/pages/categories-section.mdx
+++ b/src/content/docs/build/pages/categories-section.mdx
@@ -3,8 +3,9 @@ title: Add a Categories Section
 description: How to add a display of a grid of all available categories to your LightNet page.
 ---
 
-The `CategoriesSection` component is used to display a grid of all available categories. It already includes a `Section` 
-component to handle the layout. Clicking on a category navigates to the search page filtered by the category.
+The `CategoriesSection` component is used to display a grid of all available categories. It already includes a `Section`
+component to handle the layout. Clicking on a category navigates to the search page filtered by the category. Categories
+with an `image` property can be shown in an `image-grid` layout to highlight their images.
 
 ![Image Categories Section](./images/categories.webp)
 

--- a/src/content/docs/build/pages/categories-section.mdx
+++ b/src/content/docs/build/pages/categories-section.mdx
@@ -3,9 +3,9 @@ title: Add a Categories Section
 description: How to add a display of a grid of all available categories to your LightNet page.
 ---
 
-The `CategoriesSection` component is used to display a grid of all available categories. It already includes a `Section`
-component to handle the layout. Clicking on a category navigates to the search page filtered by the category. Categories
-with an `image` property can be shown in an `image-grid` layout to highlight their images.
+The `CategoriesSection` component is used to display the available categories. It already includes a `Section`
+component to handle the layout. Clicking on a category navigates to the search page filtered by the category.
+By default categories are presented in a carousel. Categories with an `image` property can be shown in a `grid` layout to highlight their images.
 
 ![Image Categories Section](./images/categories.webp)
 
@@ -33,3 +33,13 @@ default: `Astro.locals.i18n.t("ln.common.categories")`
 
 The title of the categories section. By default the title is translated from the `ln.common.categories` key (this is "Categories" in English).
 In case you want to use a different title, you can set the `title` property.
+
+### `layout`
+
+type: `"carousel" | "grid"` \
+example: `"grid"` \
+required: `false` \
+default: `"carousel"`
+
+Controls how the categories are arranged. The default `"carousel"` displays them in a horizontal carousel. Set `"grid"` to show categories in a grid, which highlights category images when available.
+

--- a/src/content/docs/build/pages/create-internal-links.mdx
+++ b/src/content/docs/build/pages/create-internal-links.mdx
@@ -47,9 +47,12 @@ if(!mediaItem) {
 
 Returns the localized path to the search page including preset filters.
 
-- `locale`: The current locale as provided by `Astro.currentLocale`
-- `query` (optional): Sets filters for the search page. Supported options are:
-    - `category` (optional): Filter for a category identifier.
+ - `locale`: The current locale as provided by `Astro.currentLocale`
+ - `query` (optional): Sets filters for the search page. Supported options are:
+     - `category` (optional): Filter for a category identifier.
+     - `type` (optional): Filter for a media type identifier.
+     - `language` (optional): Filter for a content language.
+     - `search` (optional): Prefill the search input with a search term.
 
 Example code that creates an anchor link to the search page filtered by the category `kids`.
 

--- a/src/content/docs/build/pages/media-gallery-section.mdx
+++ b/src/content/docs/build/pages/media-gallery-section.mdx
@@ -9,7 +9,7 @@ import { Aside } from "@astrojs/starlight/components";
 
 
 You can add a gallery of media items to your page. This is a great way to showcase your content.
-LightNet provides a `MediaGallerySection` component that displays a grid of media items.
+LightNet provides a `MediaGallerySection` component that displays a grid of media items or a carousel when configured.
 
 ![Image Media Item Gallery](./images/gallery.webp)
 
@@ -30,18 +30,19 @@ const { t } = Astro.locals.i18n
 ---
 
 <Page>
-    <MediaGallerySection 
-        title={t("x.english-books.title")} 
-        items={someEnglishBooks} 
-        layout="book"
-    />
+        <MediaGallerySection
+            title={t("x.english-books.title")}
+            items={someEnglishBooks}
+            layout="book"
+            viewLayout="carousel"
+        />
 </Page>
 ```
 
-Inside the frontmatter the `someEnglishBooks` variable is prepared using LightNet's [getMediaItems function](/build/pages/query-media-items). 
-The `MediaGallerySection` component displays them in a grid. It shows the title and image of each media item. 
-The number of grid columns depends on the screen width.
-Pass your media items to the `items` property. Also choose a layout to define the appearance of the gallery.
+ Inside the frontmatter the `someEnglishBooks` variable is prepared using LightNet's [getMediaItems function](/build/pages/query-media-items).
+ By default the `MediaGallerySection` component displays them in a grid and shows the title and image of each media item.
+ Set `viewLayout="carousel"` to render the items in a horizontal carousel.
+ Pass your media items to the `items` property. Also choose a layout to define the appearance of the gallery.
 
 ## Reference
 
@@ -75,7 +76,16 @@ to style the cover images. Available layouts are:
 - `portrait`: Takes 2 to 5 columns. Use this for cover images that are portrait oriented.
 - `book`: Takes 2 to 5 columns. This equals to `portrait` layout. Additionally a book fold is added to the cover image and corners are less rounded.
 - `landscape`: Takes 1 to 4 columns. Use this for cover images that are landscape oriented.
-- `video`: Takes 1 to 4 columns. This equals to `landscape` layout. Additionally all cover images have an aspect ratio of 16:9 with a black background.
+- `video`: Takes 1 to 4 columns. This equals to `landscape` layout. Additionally all cover images have an aspect ratio of 16:9 and the image scales to cover the entire area.
+
+### `viewLayout`
+
+type: `"grid" | "carousel"` \
+example: `"carousel"` \
+required: `false` \
+default: `"grid"`
+
+Controls the overall arrangement of items. The default `"grid"` displays items in a responsive grid. Set to `"carousel"` to render items in a horizontally scrollable carousel.
 
 <Aside>
 So far, the `MediaGallerySection` is only available in `maxWidth: "wide"`.

--- a/src/content/docs/build/pages/section.mdx
+++ b/src/content/docs/build/pages/section.mdx
@@ -36,6 +36,14 @@ required: `false`
 
 The title of the section. Is displayed above the section content.
 
+### `titleHref`
+
+type: `string` \
+example: `"/en/books"` \
+required: `false`
+
+Makes the section title a link to the provided URL. Useful for linking to pages with more content.
+
 ### `maxWidth`
 
 type: `"wide" | "narrow"` \
@@ -71,16 +79,6 @@ Sets the spacing between the section and the element above. Possible are the fol
 - `lg`: large spacing. Used on the homepage.
 - `none`: no spacing.
 
-### `disableHorizontalPadding`
-
-type: `boolean`\
-example: `true`\
-required: `false`\
-default: `false`
-
-Set to `true`, to remove padding from the left and right side of the section content.
-This setting will not apply to the section title.
-
 ### `className`
 
 type: `string` \
@@ -88,3 +86,4 @@ example: `"py-4 bg-gray-100"` \
 required: `false`
 
 Additional css classes, separated by spaces, to style the section. The classes are applied to the section's container element.
+

--- a/src/content/docs/content/categories.mdx
+++ b/src/content/docs/content/categories.mdx
@@ -5,12 +5,13 @@ description: Learn how to group your media items by different topics.
 
 import { Aside } from "@astrojs/starlight/components";
 
-Organize your media items by using categories to group them by topic. For example, you can create categories like "Theology", 
-"Christian Living," and "Kids."
+Organize your media items by using categories to group them by topic. For example, you can create categories like "Theology",
+"Christian Living," and "Kids." Categories can optionally reference an `image` that represents the category visually.
 
 Users can filter search results by these categories, making it easier to find relevant content. 
 Categories can also be used for generating a gallery of media items on the homepage.
-Categories show up on the search result items.
+Categories show up on the search result items and, when an image is present, the image is displayed in layouts such as
+`image-grid`.
 
 Here is an example of a category:
 
@@ -34,5 +35,13 @@ type: `string` \
 example: `"x.category.theology"` \
 required: `true`
 
-The label is a the name of the category that shows up on the UI. The label can either be a fixed string or a translation key 
+The label is the name of the category that shows up on the UI. The label can either be a fixed string or a translation key
 to support multiple locales.
+
+### image
+
+type: `string` \
+required: `false`
+
+Path to an image representing the category. When present the `CategoriesSection` component can render the categories in an
+`image-grid` layout to showcase these images.

--- a/src/content/docs/content/categories.mdx
+++ b/src/content/docs/content/categories.mdx
@@ -11,7 +11,7 @@ Organize your media items by using categories to group them by topic. For exampl
 Users can filter search results by these categories, making it easier to find relevant content. 
 Categories can also be used for generating a gallery of media items on the homepage.
 Categories show up on the search result items and, when an image is present, the image is displayed in layouts such as
-`image-grid`.
+`grid`.
 
 Here is an example of a category:
 
@@ -43,5 +43,5 @@ to support multiple locales.
 type: `string` \
 required: `false`
 
-Path to an image representing the category. When present the `CategoriesSection` component can render the categories in an
-`image-grid` layout to showcase these images.
+Path to an image representing the category. When present the `CategoriesSection` component can render the categories in a
+`grid` layout to showcase these images.

--- a/src/content/docs/content/media-types.mdx
+++ b/src/content/docs/content/media-types.mdx
@@ -118,8 +118,8 @@ The video layout supports YouTube URLs, Vimeo URLs and links to mp4 files.
 
 ##### layout: "audio"
 
-The audio layout shows a details page with an embedded audio player. The audio player uses the primary content URL (first item in the media item `content` array). 
-All other content URLs are shown as additional content below the audio player. An example of an audio layout configuration is:
+The audio layout shows a details page with one audio player for each mp3 found in the media item's `content` array.
+Starting a new player stops any other playing audio and playback automatically resumes with the next mp3 when one ends. An example of an audio layout configuration is:
 
 ```json
 {

--- a/src/content/docs/content/media-types.mdx
+++ b/src/content/docs/content/media-types.mdx
@@ -17,6 +17,7 @@ Here is an example of a media type:
 {
   "label": "x.type.video",
   "icon": "mdi--video-outline",
+  "coverImageStyle": "video",
   "detailsPage": {
     "layout": "video"
   }
@@ -42,8 +43,17 @@ example: `"mdi--video-outline"` \
 required: `true`
 
 The icon that indicates this type. For example this could be a "play"-icon for a video.
-It has to be in the format `mdi--[icon-name]`. With `[icon-name]` being the name of the icon from 
+It has to be in the format `mdi--[icon-name]`. With `[icon-name]` being the name of the icon from
 the [Material Design Icon](https://pictogrammers.com/library/mdi/) site.
+
+### coverImageStyle
+
+type: `"default" | "book" | "video"` \
+example: `"book"` \
+required: `false` \
+default: `"default"`
+
+Controls how cover images are rendered for media items. Use `"book"` for a book-like appearance with a fold and sharper edges. The `"video"` style forces a 16:9 aspect ratio and scales the image to cover the whole area. The existing `detailsPage.coverStyle` option is deprecated; use `coverImageStyle` instead.
 
 ### detailsPage
 
@@ -89,15 +99,6 @@ example: `"x.action.read"` \
 required: `false`
 
 The label of the button that opens the primary content URL. This needs to be a translation key. The default translates to "Open" in English.
-
-###### coverStyle
-
-type: `"default" | "book"` \
-example: `"book"` \
-required: `false` \
-default: `"default"`
-
-This sets the style of the cover image. The `book` style makes the cover image look like a book cover with sharp corners and a book fold. The default style shows the cover image as is.
 
 ##### layout: "video"
 

--- a/src/content/docs/resources/versions.mdx
+++ b/src/content/docs/resources/versions.mdx
@@ -4,5 +4,5 @@ title: Versions
 
 The docs are up to date with the following versions:
 
-- `lightnet:3.5.0`
-- `@lightnet/decap-admin:3.1.0` 
+- `lightnet:3.7.0`
+- `@lightnet/decap-admin:3.1.2`

--- a/src/content/docs/resources/versions.mdx
+++ b/src/content/docs/resources/versions.mdx
@@ -4,5 +4,5 @@ title: Versions
 
 The docs are up to date with the following versions:
 
-- `lightnet:3.7.0`
+- `lightnet:3.9.0`
 - `@lightnet/decap-admin:3.1.2`


### PR DESCRIPTION
## Summary
- document LightNet 3.7.0 / @lightnet/decap-admin 3.1.2 versions
- describe optional category images and `image-grid` layout
- mention new multi-audio player behaviour

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687a3b4a1dec83228fd94fbbfc70fea2